### PR TITLE
fix failing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: r
 sudo: required
-dist: trusty
+dist: focal
 cache:
 #  - packages
   - ccache


### PR DESCRIPTION
trusty is no longer supported by r, which is why the ci builds fail -> upgrade to focal